### PR TITLE
Instantiate SSO service only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^14.0.27"
   },
   "dependencies": {
-    "aws-sdk": "2.786.0",
+    "aws-sdk": "^2.786.0",
     "open": "^7.1.0",
     "sha1": "^1.1.1"
   },


### PR DESCRIPTION
To simplify testing and improve performance, we should only have a single SSO service in the provider. 

Exactly how it is done in the EC2 metadata credentials provider (and others): https://github.com/aws/aws-sdk-js/blob/2f68b291e1aa3137c2389bf48ac3d251f18c61f5/lib/credentials/ec2_metadata_credentials.js#L46